### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 torchvision
 numpy
 torch
-PIL
+pillow


### PR DESCRIPTION
`PIL` doesn't exist on pypi:

```bash
RROR: Could not find a version that satisfies the requirement pil (from versions: none)
ERROR: No matching distribution found for pil
```

There is pillow: https://pypi.org/project/pillow/

```python
pip install pillow
python -c "import PIL;print('success')"
>>> success
```